### PR TITLE
Find the right boundary between runtimes and programs

### DIFF
--- a/mcx/__init__.py
+++ b/mcx/__init__.py
@@ -1,13 +1,13 @@
 from mcx.model import model
 from mcx.model import sample_forward, seed
 from mcx.execution import sample, generate
-from mcx.hmc import HMC
+from mcx.inference.hmc import HMC
 
 __all__ = [
     "model",
     "seed",
-    "HMC",
     "sample_forward",
+    "HMC",
     "sample",
     "generate",
 ]

--- a/mcx/execution.py
+++ b/mcx/execution.py
@@ -1,41 +1,92 @@
+import time
+
 import jax
+import jax.numpy as np
+from jax.flatten_util import ravel_pytree
+from tqdm import tqdm
+
+from mcx import sample_forward
+from mcx.core import compile_to_logpdf
 
 
 class sample(object):
-
-    def __init__(self, rng_key, runtime, num_warmup=1000, num_chains=4, **kwargs):
+    def __init__(
+        self, rng_key, model, program, num_warmup=1000, num_chains=4, **kwargs
+    ):
         """ Initialize the sampling runtime.
         """
-        self.runtime = runtime
+        self.program = program
         self.num_chains = num_chains
         self.num_warmup = num_warmup
         self.rng_key = rng_key
 
-        initialize, build_kernel, to_trace = self.runtime
-        loglikelihood, initial_state, parameters, unravel_fn = initialize(rng_key, self.num_chains, **kwargs)
-        loglikelihood = jax.jit(loglikelihood)
+        print("Initialize the sampler")
+        print("----------------------")
 
+        init, warmup, build_kernel, to_trace = self.program
+
+        check_conditioning_variables(model, **kwargs)
+        loglikelihood = build_loglikelihood(model, **kwargs)
+
+        print("Find initial positions...", end=" ")
+        start = time.time()
+        positions, unravel_fn = get_initial_position(
+            rng_key, model, num_chains, **kwargs
+        )
+        print("Found in {:.2f}s".format(time.time() - start))
+
+        flat_loglikelihood = _flatten_logpdf(loglikelihood, unravel_fn)
+
+        print("Compute initial states...", end=" ")
+        start = time.time()
+        value_and_grad = jax.value_and_grad(flat_loglikelihood)
+        initial_state = jax.vmap(init, in_axes=(0, None))(positions, value_and_grad)
+        print("Computed in {:.2f}s".format(time.time() - start))
+
+        parameters, state = warmup(initial_state, flat_loglikelihood)
+
+        print("Compiling the log-likelihood...", end=" ")
+        start = time.time()
+        loglikelihood = jax.jit(flat_loglikelihood)
+        print("Compiled in {:.2f}s".format(time.time() - start))
+
+        print("Compiling the inference kernel...", end=" ")
+        start = time.time()
         kernel = build_kernel(loglikelihood, parameters)
-        self.kernel = jax.jit(kernel)
+        kernel = jax.jit(kernel)
+        print("Compiled in {:.2f}s".format(time.time() - start))
 
-        self.state = initial_state
-        self.unravel_fn = unravel_fn
+        self.kernel = kernel
+        self.state = state
         self.to_trace = to_trace
+        self.unravel_fn = unravel_fn
 
     def run(self, num_samples=1000):
         _, self.rng_key = jax.random.split(self.rng_key)
 
         @jax.jit
-        def update_chains(states, rng_key):
+        def update_chains(state, rng_key):
             keys = jax.random.split(rng_key, self.num_chains)
-            new_states, info = jax.vmap(self.kernel, in_axes=(0, 0))(keys, states)
-            return new_states, states
+            new_states, info = jax.vmap(self.kernel, in_axes=(0, 0))(keys, state)
+            return new_states
+
+        state = self.state
+        chain = []
 
         rng_keys = jax.random.split(self.rng_key, num_samples)
-        last_state, states = jax.lax.scan(update_chains, self.state, rng_keys)
-        self.state = last_state
+        with tqdm(rng_keys, unit="samples") as progress:
+            progress.set_description(
+                "Collecting {:,} samples across {:,} chains".format(
+                    num_samples, self.num_chains
+                ),
+                refresh=False,
+            )
+            for key in progress:
+                state = update_chains(state, key)
+                chain.append(state)
+        self.state = state
 
-        trace = self.to_trace(states, self.unravel_fn)
+        trace = self.to_trace(chain, self.unravel_fn)
 
         return trace
 
@@ -45,7 +96,9 @@ def generate(rng_key, runtime, num_warmup=1000, num_chains=4, **kwargs):
 
     initialize, build_kernel, to_trace = runtime
 
-    loglikelihood, initial_state, parameters, unravel_fn = initialize(rng_key, num_chains, **kwargs)
+    loglikelihood, initial_state, parameters, unravel_fn = initialize(
+        rng_key, num_chains, **kwargs
+    )
     loglikelihood = jax.jit(loglikelihood)
 
     kernel = build_kernel(loglikelihood, parameters)
@@ -59,3 +112,72 @@ def generate(rng_key, runtime, num_warmup=1000, num_chains=4, **kwargs):
         new_states = jax.vmap(kernel)(keys, state)
 
         yield new_states
+
+
+def check_conditioning_variables(model, **kwargs):
+    """ Check that all variables passed as arguments to the sampler
+    are random variables or arguments to the sampler. And converserly
+    that all of the model definition's positional arguments are given
+    a value.
+    """
+    conditioning_vars = set(kwargs.keys())
+    model_randvars = set(model.random_variables)
+    model_args = set(model.arguments)
+    available_vars = model_randvars.union(model_args)
+
+    # The variables passed as an argument to the initialization (variables
+    # on which the logpdf is conditionned) must be either a random variable
+    # or an argument to the model definition.
+    if not available_vars.issuperset(conditioning_vars):
+        unknown_vars = list(conditioning_vars.difference(available_vars))
+        unknown_str = ", ".join(unknown_vars)
+        raise AttributeError(
+            "You passed a value for {} which are neither random variables nor arguments to the model definition.".format(
+                unknown_str
+            )
+        )
+
+    # The user must provide a value for all of the model definition's
+    # positional arguments.
+    model_posargs = set(model.posargs)
+    if model_posargs.difference(conditioning_vars):
+        missing_vars = model_posargs.difference(conditioning_vars)
+        missing_str = ", ".join(missing_vars)
+        raise AttributeError(
+            "You need to specify a value for the following arguments: {}".format(
+                missing_str
+            )
+        )
+
+
+def build_loglikelihood(model, **kwargs):
+    artifact = compile_to_logpdf(model.graph, model.namespace)
+    logpdf = artifact.compiled_fn
+    loglikelihood = jax.partial(logpdf, **kwargs)
+    return loglikelihood
+
+
+def get_initial_position(rng_key, model, num_chains, **kwargs):
+    conditioning_vars = set(kwargs.keys())
+    model_randvars = set(model.random_variables)
+    to_sample_vars = model_randvars.difference(conditioning_vars)
+
+    samples = sample_forward(rng_key, model, num_samples=num_chains, **kwargs)
+    initial_positions = dict((var, samples[var]) for var in to_sample_vars)
+
+    positions = []
+    for i in range(num_chains):
+        position = {k: value[i] for k, value in initial_positions.items()}
+        flat_position, unravel_fn = ravel_pytree(position)
+        positions.append(flat_position)
+    positions = np.stack(positions)
+
+    return positions, unravel_fn
+
+
+def _flatten_logpdf(logpdf, unravel_fn):
+    def flattened_logpdf(array):
+        kwargs = unravel_fn(array)
+        return logpdf(**kwargs)
+
+    return flattened_logpdf

--- a/mcx/hmc.py
+++ b/mcx/hmc.py
@@ -1,13 +1,9 @@
 from typing import NamedTuple
 
-import jax
 from jax import numpy as np
-from jax.flatten_util import ravel_pytree
 
-from mcx import sample_forward
-from mcx.core import compile_to_logpdf
 from mcx.inference.integrators import velocity_verlet, hmc_proposal
-from mcx.inference.kernels import hmc_kernel, HMCState
+from mcx.inference.kernels import HMCState, hmc_kernel
 from mcx.inference.metrics import gaussian_euclidean_metric
 
 
@@ -18,68 +14,25 @@ class HMCParameters(NamedTuple):
     inverse_mass_matrix: np.DeviceArray
 
 
-def HMC(model, step_size=None, num_integration_steps=None, mass_matrix_sqrt=None, inverse_mass_matrix=None, is_mass_matrix_diagonal=True):
+def HMC(
+    step_size=None,
+    num_integration_steps=None,
+    mass_matrix_sqrt=None,
+    inverse_mass_matrix=None,
+    integrator=velocity_verlet,
+    is_mass_matrix_diagonal=True,
+):
 
-    artifact = compile_to_logpdf(model.graph, model.namespace)
-    logpdf = artifact.compiled_fn
-    parameters = HMCParameters(step_size, num_integration_steps, mass_matrix_sqrt, inverse_mass_matrix)
+    parameters = HMCParameters(
+        step_size, num_integration_steps, mass_matrix_sqrt, inverse_mass_matrix
+    )
 
-    def _flatten_logpdf(logpdf, unravel_fn):
-        def flattened_logpdf(array):
-            kwargs = unravel_fn(array)
-            return logpdf(**kwargs)
-        return flattened_logpdf
+    def init(position, value_and_grad):
+        log_prob, log_prob_grad = value_and_grad(position)
+        return HMCState(position, log_prob, log_prob_grad)
 
-    def initialize(rng_key, num_chains, **kwargs):
-        """
-        kwargs: a dictionary of arguments and variables we condition on and
-                their value.
-        """
-
-        conditioning_vars = set(kwargs.keys())
-        model_randvars = set(model.random_variables)
-        model_args = set(model.arguments)
-        available_vars = model_randvars.union(model_args)
-
-        # The variables passed as an argument to the initialization (variables
-        # on which the logpdf is conditionned) must be either a random variable
-        # or an argument to the model definition.
-        if not available_vars.issuperset(conditioning_vars):
-            unknown_vars = list(conditioning_vars.difference(available_vars))
-            unknown_str = ", ".join(unknown_vars)
-            raise AttributeError("You passed a value for {} which are neither random variables nor arguments to the model definition.".format(unknown_str))
-
-        # The user must provide a value for all of the model definition's
-        # positional arguments.
-        model_posargs = set(model.posargs)
-        if model_posargs.difference(conditioning_vars):
-            missing_vars = (model_posargs.difference(conditioning_vars))
-            missing_str = ", ".join(missing_vars)
-            raise AttributeError("You need to specify a value for the following arguments: {}".format(missing_str))
-
-        # Condition on data to obtain the model's log-likelihood
-        loglikelihood = jax.partial(logpdf, **kwargs)
-
-        # Sample one initial position per chain from the prior
-        to_sample_vars = model_randvars.difference(conditioning_vars)
-        samples = sample_forward(rng_key, model, num_samples=num_chains, **kwargs)
-        initial_positions = dict((var, samples[var]) for var in to_sample_vars)
-
-        positions = []
-        for i in range(num_chains):
-            position = {k: value[i] for k, value in initial_positions.items()}
-            flat_position, unravel_fn = ravel_pytree(position)
-            positions.append(flat_position)
-        positions = np.stack(positions)
-
-        # Transform the likelihood to use a flat array as single argument
-        flat_loglikelihood = _flatten_logpdf(loglikelihood, unravel_fn)
-
-        # Compute the log probability and gradient to define initial state
-        logprobs, logprob_grads = jax.vmap(jax.value_and_grad(flat_loglikelihood))(positions)
-        initial_state = HMCState(positions, logprobs, logprob_grads)
-
-        return flat_loglikelihood, initial_state, parameters, unravel_fn
+    def warmup(initial_state, logpdf):
+        return parameters, initial_state
 
     def build_kernel(logpdf, parameters):
         """Builds the kernel that moves the chain from one point
@@ -99,8 +52,8 @@ def HMC(model, step_size=None, num_integration_steps=None, mass_matrix_sqrt=None
         momentum_generator, kinetic_energy = gaussian_euclidean_metric(
             mass_matrix_sqrt, inverse_mass_matrix,
         )
-        integrator = velocity_verlet(logpdf, kinetic_energy)
-        proposal = hmc_proposal(integrator, step_size, num_integration_steps)
+        integrator_step = integrator(logpdf, kinetic_energy)
+        proposal = hmc_proposal(integrator_step, step_size, num_integration_steps)
         kernel = hmc_kernel(proposal, momentum_generator, kinetic_energy, logpdf)
 
         return kernel
@@ -111,4 +64,4 @@ def HMC(model, step_size=None, num_integration_steps=None, mass_matrix_sqrt=None
         """
         return states_chain
 
-    return initialize, build_kernel, to_trace
+    return init, warmup, build_kernel, to_trace

--- a/mcx/inference/hmc.py
+++ b/mcx/inference/hmc.py
@@ -20,7 +20,7 @@ def HMC(
     mass_matrix_sqrt=None,
     inverse_mass_matrix=None,
     integrator=velocity_verlet,
-    is_mass_matrix_diagonal=True,
+    is_mass_matrix_diagonal=False,
 ):
 
     parameters = HMCParameters(
@@ -31,7 +31,7 @@ def HMC(
         log_prob, log_prob_grad = value_and_grad(position)
         return HMCState(position, log_prob, log_prob_grad)
 
-    def warmup(initial_state, logpdf):
+    def warmup(initial_state, logpdf, num_warmup_steps):
         return parameters, initial_state
 
     def build_kernel(logpdf, parameters):

--- a/mcx/model.py
+++ b/mcx/model.py
@@ -357,9 +357,8 @@ def sample_forward(rng_key, model: model, num_samples=1000, **kwargs) -> Dict:
     sampler_fn = jax.jit(sampler_fn)
     samples = jax.vmap(sampler_fn, in_axes=in_axes, out_axes=out_axes)(*sampler_args)
 
-    trace = {}
-    for arg, arg_samples in zip(model.variables, samples):
-        trace[arg] = numpy.asarray(arg_samples).T.squeeze()
+    trace = {arg: numpy.asarray(arg_samples).T.squeeze() for arg, arg_samples in zip(model.variables, samples)}
+
     return trace
 
 


### PR DESCRIPTION
I am not sure what runtimes and programs' respective responsibilities are yet. This PR is an experiment to find the right API.

## Requirements

- The programs need not be aware of the models so they can be used with custom loglikelihoods. As such they can be moved to the `inference` module;
- It should be simple to use meta-algorithms like [HMC Swindles](https://arxiv.org/abs/2001.05033) and Replica exchange with an existing program;
- Runtimes are program-agnostic; they communicate via a unified API;
- One should be able to choose the integrator used in HMC;
- Warmup adapts to the parameters passed to the program;
- Runtimes come with reasonable defaults (dynamicHMC or empiricalHMC), but can easily be used with any algorithm.

## Slow initialisation

The initialisation is unacceptably slow. It is caused by repeatedly calling `ravel_pytree` for each chain. Luckily for us, `ravel_pytree` arranges the values of the dictionary in a deterministic way, sorting them by key. To fix the performance, we stack the arrays in the dictionary returned by `sample_forward` to obtained flattened position, and apply `ravel_pytree`to one dictionary to get the unraveling function.


This PR follows issue #12.