### PR TITLE
Make the tests run in parallel

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -23,4 +23,5 @@ jobs:
     - name: Test with pytest
       run: |
         pip install pytest
-        pytest tests 
+        pip install pytest-xdist
+        pytest -n 4 tests 


### PR DESCRIPTION
Testing the distribution already takes some time (~ 2 minutes) so we would
already benefit from running the tests in parallel. I added `pytest-xdist` to
the workflow that runs the tests and set up the number of threads to use to 4.
