### PR TITLE
Merge batch and iterative samplers

### DIFF
--- a/mcx/__init__.py
+++ b/mcx/__init__.py
@@ -1,9 +1,7 @@
 from mcx.model import model
 from mcx.model import sample_forward
-from mcx.sampling import batch_sampler, iterative_sampler, sequential_sampler
+from mcx.sampling import sampler, sequential_sampler
 from mcx.inference.hmc import HMC
-
-sampler = batch_sampler
 
 __all__ = [
     "model",
@@ -11,6 +9,5 @@ __all__ = [
     "sample_forward",
     "HMC",
     "sampler",
-    "iterative_sampler",
     "sequential_sampler",
 ]


### PR DESCRIPTION
Since batch and iterative sampling share the same API and philosophy it would be preferable to combine both execution models in the same object. We want to be able to do things like:

```python
sampler = mcx.sampler(...)
for sample in sampler:
	pass
```

or 

```python
sampler = mcx.sampler(...)
iter(sampler)
sample = next(sampler)
```

The first behavior is already implemented, the sampler is an iterable.

- [x] Make the sampler an iterator
- [x] Make sure the current state of the chain is carried around correctly when we switch between the  different execution models.
- [x] Enjoy the deleted code