### PR TITLE
Bump jax version

### DIFF
--- a/mcx/inference/integrators.py
+++ b/mcx/inference/integrators.py
@@ -1,5 +1,4 @@
 """Integrate hamiltonian trajectories on euclidean and riemannian manifolds."""
-from functools import partial
 from typing import Callable, NamedTuple
 
 import jax
@@ -55,7 +54,7 @@ def velocity_verlet(potential_fn: Callable, kinetic_energy_fn: Callable) -> Inte
     potential_grad_fn = jax.jit(jax.grad(potential_fn))
     kinetic_energy_grad_fn = jax.jit(jax.grad(kinetic_energy_fn))
 
-    @partial(jax.jit, static_argnums=(1,))
+    @jax.jit
     def one_step(state: IntegratorState, step_size: float) -> IntegratorState:
         position, momentum, log_prob_grad = state
 
@@ -100,7 +99,7 @@ def mclachlan_integrator(
     potential_grad_fn = jax.jit(jax.grad(potential_fn))
     kinetic_energy_grad_fn = jax.jit(jax.grad(kinetic_energy_fn))
 
-    @partial(jax.jit, static_argnums=(1,))
+    @jax.jit
     def one_step(state: IntegratorState, step_size: float) -> IntegratorState:
         position, momentum, log_prob_grad = state
 
@@ -150,7 +149,7 @@ def yoshida_integrator(
     potential_grad_fn = jax.jit(jax.grad(potential_fn))
     kinetic_energy_grad_fn = jax.jit(jax.grad(kinetic_energy_fn))
 
-    @partial(jax.jit, static_argnums=(1,))
+    @jax.jit
     def one_step(state: IntegratorState, step_size: float) -> IntegratorState:
         position, momentum, log_prob_grad = state
 
@@ -207,7 +206,7 @@ def four_stages_integrator(
     potential_grad_fn = jax.jit(jax.grad(potential_fn))
     kinetic_energy_grad_fn = jax.jit(jax.grad(kinetic_energy_fn))
 
-    @partial(jax.jit, static_argnums=(1,))
+    @jax.jit
     def one_step(state: IntegratorState, step_size: float) -> IntegratorState:
         position, momentum, log_prob_grad = state
 

--- a/mcx/inference/warmup/num_steps_adaptation.py
+++ b/mcx/inference/warmup/num_steps_adaptation.py
@@ -35,7 +35,7 @@ def longest_batch_before_turn(integrator_step: Callable) -> Callable:
             arXiv:1810.04449 (2018).
     """
 
-    @partial(jax.jit, static_argnums=(0, 1, 2, 3))
+    @partial(jax.jit, static_argnums=(2, 3))
     def run(
         initial_position: np.DeviceArray,
         initial_momentum: np.DeviceArray,
@@ -61,7 +61,7 @@ def longest_batch_before_turn(integrator_step: Callable) -> Callable:
     return run
 
 
-@partial(jax.jit, static_argnums=(0, 2))
+@jax.jit
 def is_u_turn(
     initial_position: np.DeviceArray,
     position: np.DeviceArray,

--- a/mcx/sample.py
+++ b/mcx/sample.py
@@ -127,7 +127,6 @@ class sampler(object):
 
         print("sampler: build and compile the inference kernel")
         kernel_factory = evaluator.kernel_factory(loglikelihood)
-        kernel_factory = jax.jit(kernel_factory, static_argnums=(0, 1, 2))
 
         self.is_warmed_up = False
         self.rng_key = rng_key

--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ setuptools.setup(
     install_requires=[
         "arviz==0.10.0",
         "astor",
-        "jax==0.1.77",
+        "jax",
         "jaxlib",
         "networkx",
         "numpy",

--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ setuptools.setup(
     install_requires=[
         "arviz==0.10.0",
         "astor",
-        "jax",
+        "jax==0.2.6",
         "jaxlib",
         "networkx",
         "numpy",


### PR DESCRIPTION
This fixes the 2 bugs with the older version of Jax (#36 and #58).

I then unpinned the old version of Jax. When I install everything from scratch and run the tests it passes.

Note: I also removed the static_argnums in `integtrators.py` which sets `step_size` (a float) as static. This was also causing a "non-hashable type" error for some reason. 
In any case, I don't think jitting floats adds a performance penalty (from playing around with Jax generally; I didn't test performance in this particular case).