### PR TITLE
Added multivariate normal distribution

### DIFF
--- a/mcx/distributions/__init__.py
+++ b/mcx/distributions/__init__.py
@@ -7,6 +7,7 @@ from .discrete_uniform import DiscreteUniform
 from .distribution import Distribution
 from .exponential import Exponential
 from .lognormal import LogNormal
+from .mvnormal import MvNormal
 from .normal import Normal
 from .poisson import Poisson
 from .uniform import Uniform
@@ -24,4 +25,5 @@ __all__ = [
     "Normal",
     "Poisson",
     "Uniform",
+    "MvNormal",
 ]

--- a/mcx/distributions/mvnormal.py
+++ b/mcx/distributions/mvnormal.py
@@ -1,0 +1,51 @@
+from jax import numpy as np
+from jax import random, scipy
+
+from mcx.distributions import constraints
+from mcx.distributions.distribution import Distribution
+from mcx.distributions.shapes import broadcast_batch_shape
+
+
+class MvNormal(Distribution):
+    params_constraints = {
+        "mu": constraints.real_vector,
+        "covariance_matrix": constraints.positive_definite,
+    }
+    support = constraints.real_vector
+
+    def __init__(self, mu, covariance_matrix):
+
+        (mu_event_shape,) = np.shape(mu)[-1:]
+        covariance_event_shape = np.shape(covariance_matrix)[-2:]
+        if (mu_event_shape, mu_event_shape) != covariance_event_shape:
+            raise ValueError(
+                (
+                    f"The number of dimensions implied by `mu` ({mu_event_shape}),"
+                    "does not match the dimensions implied by `covariance_matrix` "
+                    f"({covariance_event_shape})"
+                )
+            )
+
+        self.batch_shape = broadcast_batch_shape(
+            np.shape(mu)[:-1], np.shape(covariance_matrix)[:-2]
+        )
+        self.event_shape = broadcast_batch_shape(
+            np.shape(mu)[-1:], np.shape(covariance_matrix)[-2:]
+        )
+        self.mu = mu
+        self.covariance_matrix = covariance_matrix
+        super().__init__()
+
+    def sample(self, rng_key, sample_shape=()):
+        shape = sample_shape + self.batch_shape
+        draws = random.multivariate_normal(
+            rng_key, mean=self.mu, cov=self.covariance_matrix, shape=shape
+        )
+
+        return draws
+
+    # no need to check on support ]-infty, +infty[
+    def logpdf(self, x):
+        return scipy.stats.multivariate_normal.logpdf(
+            x, mean=self.mu, cov=self.covariance_matrix
+        )

--- a/tests/distributions/mvn_test.py
+++ b/tests/distributions/mvn_test.py
@@ -1,0 +1,171 @@
+import pytest
+from jax import numpy as np
+from jax import random
+
+from mcx.distributions import MvNormal
+
+
+@pytest.fixture
+def rng_key():
+    return random.PRNGKey(0)
+
+
+#
+# LOGPDF SHAPES
+#
+
+
+expected_logpdf_shapes = [
+    {
+        "x": np.array([1, 2]),
+        "mu": np.array([0, 1]),
+        "covariance_matrix": np.array([[1.0, 0.2], [0.2, 1.0]]),
+        "expected_shape": (),
+    },
+    {
+        "x": np.array([1, 2]),
+        "mu": np.array([[1, 2], [2, 1]]),
+        "covariance_matrix": np.array([[1.0, 0.2], [0.2, 1.0]]),
+        "expected_shape": (2,),
+    },
+    {
+        "x": np.array([1, 2]),
+        "mu": np.array([[1, 2], [2, 1]]),
+        "covariance_matrix": np.array(
+            [[[1.0, 0.2], [0.2, 1.0]], [[1.0, 0.3], [0.3, 1.0]]]
+        ),
+        "expected_shape": (2,),
+    },
+    {
+        "x": np.array([[1, 2], [2, 3]]),
+        "mu": np.array([[1, 2], [2, 1]]),
+        "covariance_matrix": np.array(
+            [[[1.0, 0.2], [0.2, 1.0]], [[1.0, 0.3], [0.3, 1.0]]]
+        ),
+        "expected_shape": (2,),
+    },
+]
+
+
+@pytest.mark.parametrize("case", expected_logpdf_shapes)
+def test_logpdf_shape(case):
+    log_prob = MvNormal(case["mu"], case["covariance_matrix"]).logpdf(case["x"])
+    assert log_prob.shape == case["expected_shape"]
+
+
+#
+# SAMPLING SHAPES
+#
+
+array2d_argument_expected_shapes = [
+    {"sample_shape": (), "expected_shape": (1, 2)},
+    {"sample_shape": (100,), "expected_shape": (100, 1, 2)},
+    {"sample_shape": (100, 10), "expected_shape": (100, 10, 1, 2)},
+    {"sample_shape": (1, 100), "expected_shape": (1, 100, 1, 2)},
+]
+
+
+@pytest.mark.parametrize("case", array2d_argument_expected_shapes)
+def test_sample_shape_2darray_argumentse(rng_key, case):
+    """Test the correctness of broadcasting when dimension of the MVN is
+    two. This is the simplest case of a 2d MVN"""
+
+    samples = MvNormal(np.array([1.0, 2.0]), np.array([[1.0, 0.2], [0.2, 1.0]])).sample(
+        rng_key, case["sample_shape"]
+    )
+    assert samples.shape == case["expected_shape"]
+
+
+array_argument_expected_shapes_zero_dim = [
+    {
+        "mu": np.array([[1.0, 2.0], [2.0, 1.0]]),
+        "covariance_matrix": np.array([[1, 0.3], [0.3, 1]]),
+        "sample_shape": (),
+        "expected_shape": (2, 2),
+    },
+    {
+        "mu": np.array([1.0, 2.0]),
+        "covariance_matrix": np.array([[[1, 0.3], [0.3, 1]], [[1, 0.2], [0.2, 1]]]),
+        "sample_shape": (),
+        "expected_shape": (2, 2),
+    },
+    {
+        "mu": np.array([[1.0, 2.0], [2.0, 1.0]]),
+        "covariance_matrix": np.array([[[1, 0.3], [0.3, 1]], [[1, 0.2], [0.2, 1]]]),
+        "sample_shape": (),
+        "expected_shape": (2, 2),
+    },
+]
+
+
+@pytest.mark.parametrize("case", array_argument_expected_shapes_zero_dim)
+def test_sample_shape_array_arguments_no_sample_shape(rng_key, case):
+    """Test the correctness of broadcasting when arguments can be arrays."""
+    samples = MvNormal(case["mu"], case["covariance_matrix"]).sample(
+        rng_key, case["sample_shape"]
+    )
+    assert samples.shape == case["expected_shape"]
+
+
+array_argument_expected_shapes_one_dim = [
+    {
+        "mu": np.array([[1.0, 2.0], [2.0, 1.0]]),
+        "covariance_matrix": np.array([[1, 0.3], [0.3, 1]]),
+        "sample_shape": (100,),
+        "expected_shape": (100, 2, 2),
+    },
+    {
+        "mu": np.array([1.0, 2.0]),
+        "covariance_matrix": np.array([[[1, 0.3], [0.3, 1]], [[1, 0.2], [0.2, 1]]]),
+        "sample_shape": (100,),
+        "expected_shape": (100, 2, 2),
+    },
+    {
+        "mu": np.array([[1.0, 2.0], [2.0, 1.0]]),
+        "covariance_matrix": np.array([[[1, 0.3], [0.3, 1]], [[1, 0.2], [0.2, 1]]]),
+        "sample_shape": (100,),
+        "expected_shape": (100, 2, 2),
+    },
+]
+
+
+@pytest.mark.parametrize("case", array_argument_expected_shapes_one_dim)
+def test_sample_shape_array_arguments_1d_sample_shape(rng_key, case):
+    """Test the correctness of broadcasting when arguments can be arrays
+    and sample size is not empty"""
+    samples = MvNormal(case["mu"], case["covariance_matrix"]).sample(
+        rng_key, case["sample_shape"]
+    )
+    assert samples.shape == case["expected_shape"]
+
+
+array_argument_expected_shapes_two_dim = [
+    {
+        "mu": np.array([[1.0, 2.0], [2.0, 1.0]]),
+        "covariance_matrix": np.array([[1, 0.3], [0.3, 1]]),
+        "sample_shape": (100, 2),
+        "expected_shape": (100, 2, 2, 2),
+    },
+    {
+        "mu": np.array([1.0, 2.0]),
+        "covariance_matrix": np.array([[[1, 0.3], [0.3, 1]], [[1, 0.2], [0.2, 1]]]),
+        "sample_shape": (100, 2),
+        "expected_shape": (100, 2, 2, 2),
+    },
+    {
+        "mu": np.array([[1.0, 2.0], [2.0, 1.0]]),
+        "covariance_matrix": np.array([[[1, 0.3], [0.3, 1]], [[1, 0.2], [0.2, 1]]]),
+        "sample_shape": (100, 2),
+        "expected_shape": (100, 2, 2, 2),
+    },
+]
+
+
+@pytest.mark.parametrize("case", array_argument_expected_shapes_two_dim)
+def test_sample_shape_array_arguments_2d_sample_shape(rng_key, case):
+    """Test the correctness of broadcasting when arguments can be arrays
+    and sample size is not empty"""
+    samples = MvNormal(case["mu"], case["covariance_matrix"]).sample(
+        rng_key, case["sample_shape"]
+    )
+    assert samples.shape == case["expected_shape"]


### PR DESCRIPTION
## Overview

Add MvNormal distribution. Uses `jax.scipy.multivariate_normal` for `logpdf` and `jax.random.multivariate_normal` for sampling.

## Quick tests

```
>>> import jax
>>> import jax.numpy as np
>>> import mcx
>>>
>>> rng_key = jax.random.PRNGKey(0)
>>> mvn = mcx.distributions.MvNormal(np.array([1, 2]), np.array([[1.0, 0.2], [0.2, 1.0]]))
>>> mvn.sample(rng_key)
DeviceArray([0.21523398, 2.6821878 ], dtype=float32)
>>> mvn.sample(rng_key, (3,))
DeviceArray([[1.1878438 , 0.78015494],
             [1.649418  , 3.3537068 ],
             [1.2444699 , 1.9338173 ]], dtype=float32)
>>> mvn.logpdf(np.array([1, 2]))
DeviceArray(-1.817466, dtype=float32)
>>> mvn.logpdf(np.array([[1, 2], [2, 1]]))
DeviceArray([-1.817466, -3.067466], dtype=float32)
```

Not sure the batching is broadcasting correctly though:

```
>>> mvn2 = mcx.distributions.MvNormal(
...     np.array([[1, 2], [3, 2]]), np.array([[1.0, 0.2], [0.2, 1.0]])
... )
>>> mvn2.sample(rng_key)
DeviceArray([[2.8160858, 1.6235838],
             [3.339889 , 1.5439482]], dtype=float32)
>>> mvn2.sample(rng_key, (3, 2))
DeviceArray([[[[ 1.3675394 ,  1.183653  ],
               [ 0.99355793,  1.7560301 ]],

              [[ 1.1323344 ,  0.7474071 ],
               [ 2.5944324 ,  0.161587  ]]],


             [[[-0.35665548,  2.5218964 ],
               [ 2.6202202 ,  2.0067666 ]],

              [[-0.89568627,  1.4151701 ],
               [ 3.20252   ,  3.3841357 ]]],


             [[[ 0.3996758 ,  0.86409783],
               [ 4.5410695 ,  2.3596075 ]],

              [[ 1.0302643 ,  3.2970448 ],
               [ 3.6156623 ,  3.787726  ]]]], dtype=float32)
>>> mvn.logpdf(np.array([1, 2]))
DeviceArray(-1.817466, dtype=float32)
>>> mvn.logpdf(np.array([[1, 2], [2, 1]]))
DeviceArray([-1.817466, -3.067466], dtype=float32)
```

## Pending

Proper test cases
Fixing shape issues