### PR TITLE
add progress bar for compiled inference loop

### DIFF
--- a/mcx/jax.py
+++ b/mcx/jax.py
@@ -109,7 +109,7 @@ def progress_bar_scan(num_samples):
 
         def wrapper_progress_bar(carry, x):
             iter_num = x[0]
-            iter_num = _progress_bar((iter_num, num_samples, print_rate), iter_num)
+            iter_num = _progress_bar((iter_num+1, num_samples, print_rate), iter_num)
             return func(carry, x)
 
         return wrapper_progress_bar

--- a/mcx/jax.py
+++ b/mcx/jax.py
@@ -93,7 +93,7 @@ def set_description_tqdm(message):
 
 
 def _update_tqdm(arg, transform):
-    tqdm_pbar.update(arg[0])
+    tqdm_pbar.update(arg)
 
 
 @jit
@@ -105,7 +105,7 @@ def _progress_bar(arg, result):
 
     result = lax.cond(
         iter_num % print_rate == 0,
-        lambda _: host_callback.id_tap(_update_tqdm, (print_rate, None), result=result),
+        lambda _: host_callback.id_tap(_update_tqdm, print_rate, result=result),
         lambda _: result,
         operand=None,
     )

--- a/mcx/jax.py
+++ b/mcx/jax.py
@@ -109,7 +109,7 @@ def progress_bar_scan(num_samples):
 
         def wrapper_progress_bar(carry, x):
             iter_num = x[0]
-            iter_num = _progress_bar((iter_num+1, num_samples, print_rate), iter_num)
+            iter_num = _progress_bar((iter_num + 1, num_samples, print_rate), iter_num)
             return func(carry, x)
 
         return wrapper_progress_bar

--- a/mcx/jax.py
+++ b/mcx/jax.py
@@ -78,7 +78,7 @@ def _ravel_list(*leaves):
 def _print_consumer(arg, transform):
     "Consumer for _progress_bar"
     iter_num, n_iter = arg
-    print(f"Iteration {iter_num}/{n_iter}")
+    print(f"Iteration {iter_num:,} / {n_iter:,}")
 
 
 @jit

--- a/mcx/jax.py
+++ b/mcx/jax.py
@@ -76,17 +76,24 @@ def _ravel_list(*leaves):
     return flat, unravel_list
 
 
-def define_tqdm():
+def define_tqdm(num_samples):
     global tqdm_pbar
-    tqdm_pbar = tqdm(range(10))
+    tqdm_pbar = tqdm(range(num_samples))
 
 
 def close_tqdm():
     tqdm_pbar.close()
 
 
+def set_description_tqdm(message):
+    tqdm_pbar.set_description(
+        message,
+        refresh=False,
+    )
+
+
 def _update_tqdm(arg, transform):
-    tqdm_pbar.update()
+    tqdm_pbar.update(arg[0])
 
 
 @jit
@@ -95,9 +102,10 @@ def _progress_bar(arg, result):
     Usage: carry = progress_bar((iter_num, print_rate), carry)
     """
     iter_num, print_rate = arg
+
     result = lax.cond(
         iter_num % print_rate == 0,
-        lambda _: host_callback.id_tap(_update_tqdm, (None, None), result=result),
+        lambda _: host_callback.id_tap(_update_tqdm, (print_rate, None), result=result),
         lambda _: result,
         operand=None,
     )

--- a/mcx/jax.py
+++ b/mcx/jax.py
@@ -5,8 +5,8 @@ import jax.lax as lax
 import jax.numpy as np
 from jax import jit
 from jax.dtypes import canonicalize_dtype
-from jax.tree_util import tree_flatten, tree_leaves, tree_map, tree_unflatten
 from jax.experimental import host_callback
+from jax.tree_util import tree_flatten, tree_leaves, tree_map, tree_unflatten
 
 __all__ = ["ravel_pytree", "wait_until_computed"]
 

--- a/mcx/sample.py
+++ b/mcx/sample.py
@@ -390,8 +390,7 @@ def sample_scan(
         f"Collecting {num_samples:,} samples across {num_chains:,} chains",
         refresh=False,
     )
-    print_rate = int(num_samples / 20)
-    progress_bar_scan = progress_bar_factory(progress_bar, print_rate)
+    progress_bar_scan = progress_bar_factory(progress_bar, num_samples)
 
     @jax.jit
     @progress_bar_scan

--- a/mcx/sample.py
+++ b/mcx/sample.py
@@ -390,7 +390,7 @@ def sample_scan(
         f"Collecting {num_samples:,} samples across {num_chains:,} chains",
         refresh=False,
     )
-    print_rate = int(num_samples / 10)
+    print_rate = int(num_samples / 20)
     progress_bar_scan = progress_bar_factory(progress_bar, print_rate)
 
     @jax.jit

--- a/mcx/sample.py
+++ b/mcx/sample.py
@@ -1,4 +1,3 @@
-from datetime import datetime
 from typing import Callable, Iterator, Tuple
 
 import jax
@@ -11,6 +10,7 @@ from mcx import sample_forward
 from mcx.compiler import compile_to_loglikelihoods, compile_to_logpdf
 from mcx.jax import close_tqdm, define_tqdm, progress_bar_scan
 from mcx.jax import ravel_pytree as mcx_ravel_pytree
+from mcx.jax import set_description_tqdm
 from mcx.trace import Trace
 
 __all__ = ["sampler"]
@@ -386,9 +386,6 @@ def sample_scan(
     """
     num_samples = rng_keys.shape[0]
 
-    print(f"Draw {num_samples:,} samples from {num_chains:,} chains.", end=" ")
-    start = datetime.now()
-
     @jax.jit
     @progress_bar_scan(rng_keys.shape[0])
     def update_scan(carry, x):
@@ -398,7 +395,10 @@ def sample_scan(
         state, info = jax.vmap(kernel, in_axes=(0, 0, 0))(keys, parameters, state)
         return (state, parameters), (state, info)
 
-    define_tqdm()
+    define_tqdm(num_samples)
+    set_description_tqdm(
+        f"Collecting {num_samples:,} samples across {num_chains:,} chains"
+    )
     last_state, chain = jax.lax.scan(
         update_scan, (init_state, parameters), (np.arange(rng_keys.shape[0]), rng_keys)
     )
@@ -407,7 +407,6 @@ def sample_scan(
     mcx.jax.wait_until_computed(chain)
     mcx.jax.wait_until_computed(last_state)
     close_tqdm()
-    print(f"Done in {(datetime.now()-start).total_seconds():.1f} s.")
 
     return last_chain_state, chain
 

--- a/mcx/sample.py
+++ b/mcx/sample.py
@@ -9,8 +9,8 @@ from tqdm import tqdm
 import mcx
 from mcx import sample_forward
 from mcx.compiler import compile_to_loglikelihoods, compile_to_logpdf
-from mcx.jax import ravel_pytree as mcx_ravel_pytree
 from mcx.jax import progress_bar_scan
+from mcx.jax import ravel_pytree as mcx_ravel_pytree
 from mcx.trace import Trace
 
 __all__ = ["sampler"]


### PR DESCRIPTION
I added a progress bar to the compiled version of the sampler. This implements the solution suggested in #69: scan now loops over np.arange() as well as the keys. I've tried it on a simple example and it works. Note that this progress bar is really simple compared to tqdm so it might be worth adding stuff. 

The thing I don't yet understand is that it seems to work fine for any number of chains (1 or several). I would have expected each chain to print out its progress bar. Any thoughts as to why this is?