### PR TITLE
Add pareto distribution

### DIFF
--- a/mcx/distributions/pareto.py
+++ b/mcx/distributions/pareto.py
@@ -1,0 +1,28 @@
+from jax import numpy as np
+from jax import random
+from jax.scipy import stats
+
+from mcx.distributions import constraints
+from mcx.distributions.distribution import Distribution
+from mcx.distributions.shapes import broadcast_batch_shape
+
+
+class Pareto(Distribution):
+    parameters = {
+        "b": constraints.strictly_positive,
+    }
+
+    def __init__(self, a, m):
+        self.support = constraints.closed_interval(m, np.inf)
+        self.event_shape = ()
+        self.batch_shape = broadcast_batch_shape(np.shape(a), np.shape(m))
+        self.a = a
+        self.m = m
+
+    def sample(self, rng_key, sample_shape=()):
+        shape = sample_shape + self.batch_shape + self.event_shape
+        return random.pareto(key=rng_key, b=self.b, shape=shape)
+
+    @constraints.limit_to_support
+    def logpdf(self, x):
+        return stats.pareto.logpdf(x=x, b=self.b, loc=self.m)


### PR DESCRIPTION
I'm not familiar really with this distribution and am a bit confused with all the different ways it is parameterized depending on which library you look at, for example [Stan](https://mc-stan.org/docs/2_22/functions-reference/pareto-distribution.html) and [PyMC3](https://docs.pymc.io/api/distributions/continuous.html#pymc3.distributions.continuous.Pareto) both use a shape and scale parameter but the [jax.scipy.stats](https://jax.readthedocs.io/en/latest/_autosummary/jax.scipy.stats.pareto.logpdf.html#jax.scipy.stats.pareto.logpdf) implementation uses a parameter `b` as well as a `loc` and `scale` parameter. I am not sure which would be preferable to use, some guidance/input would be appreciated. 🙏 