### PR TITLE
Add HalfNormal distribution

### DIFF
--- a/mcx/distributions/__init__.py
+++ b/mcx/distributions/__init__.py
@@ -8,6 +8,7 @@ from .discrete_uniform import DiscreteUniform
 from .distribution import Distribution
 from .exponential import Exponential
 from .gamma import Gamma
+from .halfnormal import HalfNormal
 from .lognormal import LogNormal
 from .mvnormal import MvNormal
 from .normal import Normal
@@ -27,6 +28,7 @@ __all__ = [
     "Gamma",
     "LogNormal",
     "MvNormal",
+    "HalfNormal",
     "Normal",
     "Poisson",
     "Uniform",

--- a/mcx/distributions/constraints.py
+++ b/mcx/distributions/constraints.py
@@ -34,7 +34,6 @@ __all__ = [
     "interval",
     "integer",
     "integer_interval",
-    "whole_number",
     "positive_integer",
     "positive",
     "probability",
@@ -221,7 +220,6 @@ integer = _Integer()
 integer_interval = _IntegerInterval
 interval = _Interval
 positive_integer = _IntegerGreaterThan(0)
-whole_number = _IntegerGreaterThan(-1)
 positive = _GreaterThan(0.0)
 positive_definite = _PositiveDefinite()
 probability = _Interval(0.0, 1.0)

--- a/mcx/distributions/halfnormal.py
+++ b/mcx/distributions/halfnormal.py
@@ -1,0 +1,29 @@
+from jax import lax
+from jax import numpy as jnp
+from jax import random, scipy
+
+from mcx.distributions import constraints
+from mcx.distributions.distribution import Distribution
+
+
+class HalfNormal(Distribution):
+    params_constraints = {
+        "sigma": constraints.strictly_positive,
+    }
+    support = constraints.positive
+
+    def __init__(self, sigma):
+        self.event_shape = ()
+        self.batch_shape = jnp.shape(sigma)
+        self.sigma = sigma
+
+    def sample(self, rng_key, sample_shape=()):
+        shape = sample_shape + self.batch_shape + self.event_shape
+        std_sample = random.truncated_normal(rng_key, lower=0, upper=None, shape=shape)
+        return self.sigma * std_sample
+
+    @constraints.limit_to_support
+    def logpdf(self, x):
+        return lax.add(
+            scipy.stats.norm.logpdf(x, loc=0, scale=self.sigma), lax.log(2.0)
+        )

--- a/mcx/distributions/poisson.py
+++ b/mcx/distributions/poisson.py
@@ -7,7 +7,7 @@ from mcx.distributions.distribution import Distribution
 
 class Poisson(Distribution):
     parameters = {"lambda": constraints.positive}
-    support = constraints.whole_number
+    support = constraints.positive_integer
 
     def __init__(self, lmbda):
         self.event_shape = ()

--- a/tests/distributions/halfnormal_test.py
+++ b/tests/distributions/halfnormal_test.py
@@ -1,0 +1,131 @@
+import pytest
+from jax import numpy as jnp
+from jax import random
+
+from mcx.distributions import HalfNormal
+
+
+@pytest.fixture
+def rng_key():
+    return random.PRNGKey(0)
+
+
+#
+# LOGPDF SHAPES
+#
+
+expected_logpdf_shapes = [
+    {"x": 1, "sigma": 1, "expected_shape": ()},
+    {"x": 1, "sigma": jnp.array([1, 2]), "expected_shape": (2,)},
+]
+
+
+@pytest.mark.parametrize("case", expected_logpdf_shapes)
+def test_logpdf_shape(case):
+    log_prob = HalfNormal(case["sigma"]).logpdf(case["x"])
+    assert log_prob.shape == case["expected_shape"]
+
+
+#
+# SAMPLING SHAPES
+#
+
+scalar_argument_expected_shapes = [
+    {"sample_shape": (), "expected_shape": ()},
+    {"sample_shape": (100,), "expected_shape": (100,)},
+    {
+        "sample_shape": (100, 10),
+        "expected_shape": (
+            100,
+            10,
+        ),
+    },
+    {
+        "sample_shape": (1, 100),
+        "expected_shape": (
+            1,
+            100,
+        ),
+    },
+]
+
+
+@pytest.mark.parametrize("case", scalar_argument_expected_shapes)
+def test_sample_shape_scalar_arguments(rng_key, case):
+    """Test the correctness of broadcasting when both arguments are
+    scalars. We test scalars arguments separately from array arguments
+    since scalars are edge cases when it comes to broadcasting.
+
+    """
+    samples = HalfNormal(1).sample(rng_key, case["sample_shape"])
+    assert samples.shape == case["expected_shape"]
+
+
+array_argument_expected_shapes_zero_dim = [
+    {
+        "sigma": jnp.array([1, 2, 3]),
+        "sample_shape": (),
+        "expected_shape": (3,),
+    },
+    {
+        "sigma": jnp.array([[1, 2], [3, 4]]),
+        "sample_shape": (),
+        "expected_shape": (2, 2),
+    },
+]
+
+
+@pytest.mark.parametrize("case", array_argument_expected_shapes_zero_dim)
+def test_sample_shape_array_arguments_no_sample_shape(rng_key, case):
+    """Test the correctness of broadcasting when arguments can be arrays."""
+    samples = HalfNormal(case["sigma"]).sample(rng_key, case["sample_shape"])
+    assert samples.shape == case["expected_shape"]
+
+
+array_argument_expected_shapes_one_dim = [
+    {
+        "sigma": jnp.array([1, 2, 3]),
+        "sample_shape": (100,),
+        "expected_shape": (100, 3),
+    },
+    {
+        "sigma": jnp.array([[1, 2], [3, 4]]),
+        "sample_shape": (100,),
+        "expected_shape": (100, 2, 2),
+    },
+]
+
+
+@pytest.mark.parametrize("case", array_argument_expected_shapes_one_dim)
+def test_sample_shape_array_arguments_1d_sample_shape(rng_key, case):
+    samples = HalfNormal(case["sigma"]).sample(rng_key, case["sample_shape"])
+    assert samples.shape == case["expected_shape"]
+
+
+array_argument_expected_shapes_two_dims = [
+    {
+        "sigma": jnp.array([1, 2, 3]),
+        "sample_shape": (100, 2),
+        "expected_shape": (100, 2, 3),
+    },
+    {
+        "sigma": jnp.array([[1, 2], [3, 4]]),
+        "sample_shape": (100, 2),
+        "expected_shape": (100, 2, 2, 2),
+    },
+]
+
+
+@pytest.mark.parametrize("case", array_argument_expected_shapes_two_dims)
+def test_sample_shape_array_arguments_2d_sample_shape(rng_key, case):
+    samples = HalfNormal(case["sigma"]).sample(rng_key, case["sample_shape"])
+    assert samples.shape == case["expected_shape"]
+
+
+out_of_support_cases = [{"x": -1, "expected": -jnp.inf}]
+
+
+@pytest.mark.parametrize("case", out_of_support_cases)
+def test_out_of_support(case):
+    logprob = HalfNormal(1).logpdf(case["x"])
+    assert logprob == case["expected"]

--- a/tests/distributions/poisson_test.py
+++ b/tests/distributions/poisson_test.py
@@ -20,28 +20,15 @@ def rng_key():
 #
 
 out_of_support_cases = [
-    {"x": -1.0, "lmbda": 1.0, "expected": -jnp.inf},
-    {"x": 1.0, "lmbda": 0.0, "expected": -jnp.inf},
-    {"x": 1.1, "lmbda": 1.0, "expected": -jnp.inf},
+    {"x": -1.0, "expected": -jnp.inf},
+    {"x": 1.1, "expected": -jnp.inf},
 ]
 
 
 @pytest.mark.parametrize("case", out_of_support_cases)
 def test_logpdf_out_of_support(case):
-    logprob = Poisson(case["lmbda"]).logpdf(case["x"])
-    assert jnp.isclose(logprob, case["expected"])
-
-
-cases = [
-    {"x": 0.0, "expected": -1.0, "lmbda": 1.0},
-    {"x": 0.0, "expected": -5.0, "lmbda": 5.0},
-]
-
-
-@pytest.mark.parametrize("case", cases)
-def test_logpdf_at_zero(case):
-    logprob = Poisson(case["lmbda"]).logpdf(case["x"])
-    assert jnp.isclose(logprob, case["expected"])
+    logprob = Poisson(1.0).logpdf(case["x"])
+    assert logprob == case["expected"]
 
 
 #
@@ -52,10 +39,8 @@ def test_logpdf_at_zero(case):
 @pytest.mark.parametrize(
     ["lmbda", "sample_shape", "expected_shape"],
     [
-        # 5 1d samples
-        [jnp.array(1), (5,), (5,)],
-        # 5 samples from 2 poisson distributions
-        [jnp.array([1, 2]), (5,), (5, 2)],
+        [jnp.array(1), (5,), (5,)],  # 5 1d samples
+        [jnp.array([1, 2]), (5,), (5, 2)],  # 5 samples from 2 poisson distributions
         [jnp.array([1, 2]), (5, 2), (5, 2, 2)],
         [
             jnp.array([1, 2, 0, 0]),
@@ -70,8 +55,7 @@ def test_logpdf_at_zero(case):
     ],
 )
 def test_sampling_shape(lmbda, expected_shape, sample_shape, rng_key):
-    poisson_samples = Poisson(lmbda=lmbda).sample(rng_key, sample_shape)
-    assert poisson_samples.shape == expected_shape
+    assert Poisson(lmbda=lmbda).sample(rng_key, sample_shape).shape == expected_shape
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
Adds the HalfNormal distribution. I force it to be bounded below at 0 to match the APIs of other PPL libraries (e.g. [numpyro](https://numpyro.readthedocs.io/en/v0.2.0/distributions.html#halfnormal), [tensorflow probability](https://www.tensorflow.org/probability/api_docs/python/tfp/distributions/HalfNormal)