### PR TITLE
Bugfix: Poisson logpdf correctness at x=0

### DIFF
--- a/mcx/distributions/constraints.py
+++ b/mcx/distributions/constraints.py
@@ -34,6 +34,7 @@ __all__ = [
     "interval",
     "integer",
     "integer_interval",
+    "whole_number",
     "positive_integer",
     "positive",
     "probability",
@@ -220,6 +221,7 @@ integer = _Integer()
 integer_interval = _IntegerInterval
 interval = _Interval
 positive_integer = _IntegerGreaterThan(0)
+whole_number = _IntegerGreaterThan(-1)
 positive = _GreaterThan(0.0)
 positive_definite = _PositiveDefinite()
 probability = _Interval(0.0, 1.0)

--- a/mcx/distributions/poisson.py
+++ b/mcx/distributions/poisson.py
@@ -18,6 +18,5 @@ class Poisson(Distribution):
         shape = sample_shape + self.batch_shape + self.event_shape
         return random.poisson(rng_key, self.lmbda, shape)
 
-    @constraints.limit_to_support
     def logpdf(self, k):
         return scipy.stats.poisson.logpmf(k, self.lmbda)

--- a/mcx/distributions/poisson.py
+++ b/mcx/distributions/poisson.py
@@ -7,7 +7,7 @@ from mcx.distributions.distribution import Distribution
 
 class Poisson(Distribution):
     parameters = {"lambda": constraints.positive}
-    support = constraints.positive_integer
+    support = constraints.whole_number
 
     def __init__(self, lmbda):
         self.event_shape = ()
@@ -18,5 +18,6 @@ class Poisson(Distribution):
         shape = sample_shape + self.batch_shape + self.event_shape
         return random.poisson(rng_key, self.lmbda, shape)
 
+    @constraints.limit_to_support
     def logpdf(self, k):
         return scipy.stats.poisson.logpmf(k, self.lmbda)

--- a/tests/distributions/poisson_test.py
+++ b/tests/distributions/poisson_test.py
@@ -22,6 +22,7 @@ def rng_key():
 out_of_support_cases = [
     {"x": -1.0, "lmbda": 1.0, "expected": -jnp.inf},
     {"x": 1.0, "lmbda": 0.0, "expected": -jnp.inf},
+    {"x": 1.1, "lmbda": 1.0, "expected": -jnp.inf},
 ]
 
 


### PR DESCRIPTION
I noticed unexpected/incorrect behavior of the Poisson distribution- mainly that `dist.Poisson(1).logpdf(0.)` evaluated to `-jnp.inf`, rather than -1.

This PR updates the support constraint  that was causing this at this edge case. Behavior from the `logpmf` function of the poisson distribution in `scipy.stats` covers the expected behavior of the `logpmf` function outside of the domain of both `x` and `lmbda`.

I've added a couple of new unit tests.